### PR TITLE
Fail fast when a new database transaction cannot be started.

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -188,10 +188,16 @@ func (d *dbChecker) unreachable() bool {
 	return d.checking
 }
 
-func (d *dbChecker) start() {
+func (d *dbChecker) start() bool {
 	d.Lock()
 	defer d.Unlock()
+
+	if d.checking {
+		return false
+	}
+
 	d.checking = true
+	return true
 }
 
 func (d *dbChecker) stop() {
@@ -201,12 +207,11 @@ func (d *dbChecker) stop() {
 }
 
 func (d *dbChecker) check(db *sql.DB, duration time.Duration) {
-	if d.unreachable() {
+	if !d.start() {
 		// already checking
 		return
 	}
 
-	d.start()
 	for range time.Tick(2 * time.Second) {
 		tx, err := newTx(db, duration)
 		if err != nil {


### PR DESCRIPTION
We need a new approach to handle database failures. Since db.Begin() blocks
when the database server is not responding, the current implementation, in the
worst case, sleeps a given duration for each request. This cannot be an option;
it can exhaust server resources quickly under high loads.  This commit
implements a simple solution that starts a goroutine to check database
periodically. When the database server still freezed all the following requests
will fail and will not wait sleeping.
@joaopetreli @rafaeljusto 
