### PR TITLE
Refactory transaction cancellation

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -152,8 +152,8 @@ func newTx(db *sql.DB, timeout time.Duration) (*sql.Tx, error) {
 	// until the program dies.
 	ch := make(chan *sql.Tx, 1)
 	chErr := make(chan error, 1)
+	cancel := make(chan bool, 1)
 
-	cancel := false
 	go func() {
 		tx, err := db.Begin()
 		if err != nil {
@@ -162,18 +162,23 @@ func newTx(db *sql.DB, timeout time.Duration) (*sql.Tx, error) {
 		}
 
 		ch <- tx
-		if cancel {
+
+		if c, ok := <-cancel; ok && c {
+			// commit the transaction to release the resource, because the timeout was
+			// reached before the transaction was created.
 			tx.Commit()
 		}
 	}()
 
 	select {
 	case tx := <-ch:
+		cancel <- false
 		return tx, nil
 	case err := <-chErr:
+		close(cancel)
 		return nil, err
 	case <-time.After(timeout):
-		cancel = true
+		cancel <- true
 		return nil, ErrNewTxTimedOut
 	}
 }


### PR DESCRIPTION
To avoid concurrency problems that could leave a DB transaction open, the
cancellation strategy is now using a channel.

See #8
