### PR TITLE
New reflection package with useful features

### DIFF
--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -10,16 +10,19 @@ func IsDefined(value interface{}) bool {
 		return false
 	}
 
-	v := reflect.ValueOf(value)
-	switch v.Kind() {
+	return isDefined(reflect.ValueOf(value))
+}
+
+func isDefined(value reflect.Value) bool {
+	switch value.Kind() {
 	case reflect.Ptr, reflect.Interface:
-		if canIsNil(v.Elem()) {
-			v = v.Elem()
+		if canIsNil(value.Elem()) {
+			return isDefined(value.Elem())
 		}
 	}
 
-	if canIsNil(v) {
-		return !v.IsNil()
+	if canIsNil(value) {
+		return !value.IsNil()
 	}
 
 	return true

--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -1,0 +1,35 @@
+// Package reflect adds some useful features to the standard reflect package.
+package reflect
+
+import "reflect"
+
+// IsDefined checks if the value is different from nil looking further to its
+// contents.
+func IsDefined(value interface{}) bool {
+	if value == nil {
+		return false
+	}
+
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		if canIsNil(v.Elem()) {
+			v = v.Elem()
+		}
+	}
+
+	if canIsNil(v) {
+		return !v.IsNil()
+	}
+
+	return true
+}
+
+func canIsNil(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
+		return true
+	}
+
+	return false
+}

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -1,0 +1,95 @@
+package reflect_test
+
+import (
+	"testing"
+
+	"fmt"
+
+	"github.com/registrobr/gostk/reflect"
+)
+
+func TestIsDefined(t *testing.T) {
+	scenarios := []struct {
+		description string
+		value       interface{}
+		expected    bool
+	}{
+		{
+			description: "it should detect nil",
+			expected:    false,
+		},
+		{
+			description: "it should detect an undefined pointer",
+			value: func() interface{} {
+				var value *int
+				return value
+			}(),
+			expected: false,
+		},
+		{
+			description: "it should detect an undefined slice",
+			value: func() interface{} {
+				var value []int
+				return value
+			}(),
+			expected: false,
+		},
+		{
+			description: "it should detect a type that refers to an undefined slice",
+			value: func() interface{} {
+				type t []int
+				var value t
+				return value
+			}(),
+			expected: false,
+		},
+		{
+			description: "it should detect a pointer of a type that refers to an undefined slice",
+			value: func() interface{} {
+				type t []int
+				var value1 t
+				var value2 = &value1
+				return value2
+			}(),
+			expected: false,
+		},
+		{
+			description: "it should detect a defined struct",
+			value:       struct{ value int }{},
+			expected:    true,
+		},
+		{
+			description: "it should detect a pointer to a defined struct",
+			value:       &struct{ value int }{},
+			expected:    true,
+		},
+		{
+			description: "it should detect a pointer of a type that refers to a defined slice",
+			value: func() interface{} {
+				type t []int
+				value1 := t{1, 2, 3}
+				var value2 = &value1
+				return value2
+			}(),
+			expected: true,
+		},
+	}
+
+	for i, scenario := range scenarios {
+		if result := reflect.IsDefined(scenario.value); result != scenario.expected {
+			t.Errorf("scenario %d, “%s”: mismatch result. Expecting: “%t”; found “%t”",
+				i, scenario.description, scenario.expected, result)
+		}
+	}
+}
+
+// ExampleIsDefined show the common case where there's a need to inspect deeper
+// if a value is nil or not.
+func ExampleIsDefined() {
+	type mytype []int
+	var value1 mytype
+	var value2 = &value1
+
+	fmt.Println(reflect.IsDefined(value2))
+	// Output: false
+}


### PR DESCRIPTION
When working with generic types there's no function in the standard reflect
package to check if an interface{} is defined or not. A simple reflect.IsNil
will not work on cases where the interface{} is a pointer to an undefined
slice.
