### PR TITLE
Set Postgresql default port

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -74,6 +74,10 @@ func NewConnParams() ConnParams {
 // connection it returns a sql.DB and a nil error. In case of problem it returns a nil sql.DB and an
 // error from sql.Open (standard library, see https://golang.org/pkg/database/sql/#Open)
 func ConnectPostgres(d ConnParams) (db *sql.DB, err error) {
+	if d.Port == 0 {
+		d.Port = 5432
+	}
+
 	// connect_timeout
 	//
 	// https://www.postgresql.org/docs/9.6/static/libpq-connect.html#LIBPQ-CONNECT-CONNECT-TIMEOUT

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -31,7 +31,7 @@ func TestConnectPostgres(t *testing.T) {
 			}(),
 			postgresDriver: "testdb",
 			openFunc: func(dsn string) (driver.Conn, error) {
-				connParams := "user=user password=passwd dbname=test sslmode=disable host=127.0.0.1 connect_timeout=3 statement_timeout=10000"
+				connParams := "user=user password=passwd dbname=test sslmode=disable host=127.0.0.1 port=5432 connect_timeout=3 statement_timeout=10000"
 				if dsn != connParams {
 					return nil, fmt.Errorf("invalid connection string")
 				}
@@ -66,6 +66,11 @@ func TestConnectPostgres(t *testing.T) {
 		testdb.SetOpenFunc(scenario.openFunc)
 		db.PostgresDriver = scenario.postgresDriver
 		db, err := db.ConnectPostgres(scenario.connParams)
+
+		// call Begin to force database/sql call our scenario.openFunc
+		if err == nil {
+			_, err = db.Begin()
+		}
 
 		if scenario.expectedError == nil && db == nil {
 			t.Errorf("scenario %d, “%s”: database not initialized",

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -51,6 +51,27 @@ func TestConnectPostgres(t *testing.T) {
 			postgresDriver: "idontexist",
 			expectedError:  fmt.Errorf(`sql: unknown driver "idontexist" (forgotten import?)`),
 		},
+		{
+			description: "check if it is setting default postgres port 5432",
+			connParams: func() db.ConnParams {
+				d := db.NewConnParams()
+				d.DatabaseName = "test"
+				d.Username = "user"
+				d.Password = "passwd"
+				d.Host = "127.0.0.1"
+				d.Port = 0
+				return d
+			}(),
+			postgresDriver: "testdb",
+			openFunc: func(dsn string) (driver.Conn, error) {
+				connParams := "user=user password=passwd dbname=test sslmode=disable host=127.0.0.1 port=5432 connect_timeout=3 statement_timeout=10000"
+				if dsn != connParams {
+					return nil, fmt.Errorf("invalid connection string")
+				}
+
+				return testdb.Conn(), nil
+			},
+		},
 	}
 
 	originalPostgresDriver := db.PostgresDriver


### PR DESCRIPTION
As a client point of view it's usually expected when _database connection port_ was not set that it fall to its default value. This pull request implement the expected behavior.

Also there was a bug in db_test.go: When sql.Open is called it delays a database opening until a call of Begin. Thus, the _scenario.openFunc_ was not being called and tests are not failing as it should being.
